### PR TITLE
feat: app state + TUI render

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,1 +1,191 @@
+// App state is not yet wired into main — suppress dead_code for this WIP module.
+#![allow(dead_code)]
 
+use crate::scanner::ArtifactEntry;
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AppStatus {
+    Scanning,
+    Ready,
+    ConfirmDelete,
+    Deleting,
+    Done,
+}
+
+#[derive(Debug)]
+pub struct AppState {
+    pub entries: Vec<ArtifactEntry>,
+    pub selected: HashSet<usize>,
+    pub cursor: usize,
+    pub status: AppStatus,
+    pub root: PathBuf,
+}
+
+impl AppState {
+    pub fn new(root: PathBuf) -> Self {
+        Self {
+            entries: Vec::new(),
+            selected: HashSet::new(),
+            cursor: 0,
+            status: AppStatus::Scanning,
+            root,
+        }
+    }
+
+    pub fn add_entry(&mut self, entry: ArtifactEntry) {
+        self.entries.push(entry);
+    }
+
+    pub fn mark_scan_done(&mut self) {
+        self.status = AppStatus::Ready;
+    }
+
+    pub fn move_up(&mut self) {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+        }
+    }
+
+    pub fn move_down(&mut self) {
+        if !self.entries.is_empty() && self.cursor < self.entries.len() - 1 {
+            self.cursor += 1;
+        }
+    }
+
+    pub fn toggle_selected(&mut self) {
+        if self.entries.is_empty() {
+            return;
+        }
+        if self.selected.contains(&self.cursor) {
+            self.selected.remove(&self.cursor);
+        } else {
+            self.selected.insert(self.cursor);
+        }
+    }
+
+    pub fn toggle_select_all(&mut self) {
+        if self.entries.is_empty() {
+            return;
+        }
+        if self.selected.len() == self.entries.len() {
+            self.selected.clear();
+        } else {
+            self.selected = (0..self.entries.len()).collect();
+        }
+    }
+
+    pub fn selected_size_bytes(&self) -> u64 {
+        self.selected
+            .iter()
+            .filter_map(|&i| self.entries.get(i))
+            .map(|e| e.size_bytes)
+            .sum()
+    }
+
+    pub fn selected_paths(&self) -> Vec<PathBuf> {
+        let mut indices: Vec<usize> = self.selected.iter().cloned().collect();
+        indices.sort_unstable();
+        indices
+            .iter()
+            .filter_map(|&i| self.entries.get(i))
+            .map(|e| e.path.clone())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scanner::{ArtifactEntry, Language};
+
+    fn make_entry(name: &str, size: u64) -> ArtifactEntry {
+        ArtifactEntry {
+            path: PathBuf::from(name),
+            language: Language::Rust,
+            size_bytes: size,
+        }
+    }
+
+    fn state_with_three() -> AppState {
+        let mut s = AppState::new(PathBuf::from("."));
+        s.add_entry(make_entry("a/target", 100));
+        s.add_entry(make_entry("b/target", 200));
+        s.add_entry(make_entry("c/target", 300));
+        s
+    }
+
+    #[test]
+    fn move_down_advances_cursor() {
+        let mut s = state_with_three();
+        s.move_down();
+        assert_eq!(s.cursor, 1);
+    }
+
+    #[test]
+    fn move_down_clamps_at_last() {
+        let mut s = state_with_three();
+        s.cursor = 2;
+        s.move_down();
+        assert_eq!(s.cursor, 2);
+    }
+
+    #[test]
+    fn move_up_clamps_at_zero() {
+        let mut s = state_with_three();
+        s.move_up();
+        assert_eq!(s.cursor, 0);
+    }
+
+    #[test]
+    fn toggle_selected_adds_and_removes() {
+        let mut s = state_with_three();
+        s.toggle_selected();
+        assert!(s.selected.contains(&0));
+        s.toggle_selected();
+        assert!(!s.selected.contains(&0));
+    }
+
+    #[test]
+    fn toggle_select_all_selects_all() {
+        let mut s = state_with_three();
+        s.toggle_select_all();
+        assert_eq!(s.selected.len(), 3);
+    }
+
+    #[test]
+    fn toggle_select_all_clears_when_all_selected() {
+        let mut s = state_with_three();
+        s.toggle_select_all();
+        s.toggle_select_all();
+        assert!(s.selected.is_empty());
+    }
+
+    #[test]
+    fn selected_size_sums_only_selected() {
+        let mut s = state_with_three();
+        s.selected.insert(0); // 100
+        s.selected.insert(2); // 300
+        assert_eq!(s.selected_size_bytes(), 400);
+    }
+
+    #[test]
+    fn selected_paths_returns_sorted() {
+        let mut s = state_with_three();
+        s.selected.insert(2);
+        s.selected.insert(0);
+        let paths = s.selected_paths();
+        assert_eq!(paths[0], PathBuf::from("a/target"));
+        assert_eq!(paths[1], PathBuf::from("c/target"));
+    }
+
+    #[test]
+    fn toggle_select_all_on_empty_list_is_noop() {
+        let mut s = AppState::new(PathBuf::from("."));
+        s.toggle_select_all(); // should not panic, selected stays empty
+        assert!(s.selected.is_empty());
+        s.toggle_select_all(); // still a noop
+        assert!(s.selected.is_empty());
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,1 +1,127 @@
+// UI render is not yet wired into main — suppress dead_code for this WIP module.
+#![allow(dead_code)]
 
+use crate::app::{AppState, AppStatus};
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+    Frame,
+};
+
+pub fn render(f: &mut Frame, state: &AppState, list_state: &mut ListState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(0),
+            Constraint::Length(3),
+        ])
+        .split(f.area());
+
+    // Header
+    let header_text = match &state.status {
+        AppStatus::Scanning => format!("scanning {}...", state.root.display()),
+        AppStatus::Ready => format!("done — {} items found", state.entries.len()),
+        AppStatus::ConfirmDelete => format!(
+            "Delete {} folder(s) ({})? [y/N]",
+            state.selected.len(),
+            format_bytes(state.selected_size_bytes())
+        ),
+        AppStatus::Deleting => "deleting...".to_string(),
+        AppStatus::Done => "done".to_string(),
+    };
+
+    f.render_widget(
+        Paragraph::new(header_text).block(Block::default().borders(Borders::ALL).title(" irona ")),
+        chunks[0],
+    );
+
+    // List
+    let items: Vec<ListItem> = state
+        .entries
+        .iter()
+        .enumerate()
+        .map(|(i, entry)| {
+            let check = if state.selected.contains(&i) {
+                "[✓]"
+            } else {
+                "[ ]"
+            };
+            let name = entry.path.file_name().unwrap_or_default().to_string_lossy();
+            let parent = entry.path.parent().unwrap_or(&entry.path).to_string_lossy();
+            ListItem::new(Line::from(vec![
+                Span::raw(format!(" {} ", check)),
+                Span::styled(format!("{:<15}", name), Style::default().fg(Color::Cyan)),
+                Span::raw(format!("  {:<45}", parent)),
+                Span::styled(
+                    format!("{:>10}", format_bytes(entry.size_bytes)),
+                    Style::default().fg(Color::Yellow),
+                ),
+            ]))
+        })
+        .collect();
+
+    f.render_stateful_widget(
+        List::new(items)
+            .block(Block::default().borders(Borders::ALL))
+            .highlight_style(
+                Style::default()
+                    .bg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        chunks[1],
+        list_state,
+    );
+
+    // Footer
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(
+                format!("Selected: {}   ", format_bytes(state.selected_size_bytes())),
+                Style::default().fg(Color::Green),
+            ),
+            Span::raw("↑↓ navigate  Space select  a all  d delete  q quit"),
+        ]))
+        .block(Block::default().borders(Borders::ALL)),
+        chunks[2],
+    );
+}
+
+pub fn format_bytes(bytes: u64) -> String {
+    if bytes >= 1_073_741_824 {
+        format!("{:.1} GB", bytes as f64 / 1_073_741_824.0)
+    } else if bytes >= 1_048_576 {
+        format!("{:.1} MB", bytes as f64 / 1_048_576.0)
+    } else if bytes >= 1_024 {
+        format!("{:.1} KB", bytes as f64 / 1_024.0)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_bytes_gb() {
+        assert_eq!(format_bytes(1_073_741_824), "1.0 GB");
+    }
+
+    #[test]
+    fn format_bytes_mb() {
+        assert_eq!(format_bytes(1_048_576), "1.0 MB");
+    }
+
+    #[test]
+    fn format_bytes_kb() {
+        assert_eq!(format_bytes(1_024), "1.0 KB");
+    }
+
+    #[test]
+    fn format_bytes_bytes() {
+        assert_eq!(format_bytes(512), "512 B");
+    }
+}


### PR DESCRIPTION
## Summary

- `AppState` with navigation/selection/size logic (8 tests): cursor movement, toggle selection, select-all, selected size sum, sorted path list
- Ratatui header/list/footer render with `format_bytes` helper (4 tests): GB/MB/KB/B formatting
- Both modules carry `#![allow(dead_code)]` matching the existing `scanner.rs` convention — they will be wired in Phase 4

## Test plan

- [ ] `cargo nextest run` — 18 tests pass (6 scanner + 8 app + 4 ui)
- [ ] `cargo clippy --all-targets -- -D warnings` — clean, no warnings
- [ ] `cargo fmt` — no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)