### PR TITLE
feat: wire deleter + main event loop

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,1 +1,191 @@
+// App state is not yet wired into main — suppress dead_code for this WIP module.
+#![allow(dead_code)]
 
+use crate::scanner::ArtifactEntry;
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AppStatus {
+    Scanning,
+    Ready,
+    ConfirmDelete,
+    Deleting,
+    Done,
+}
+
+#[derive(Debug)]
+pub struct AppState {
+    pub entries: Vec<ArtifactEntry>,
+    pub selected: HashSet<usize>,
+    pub cursor: usize,
+    pub status: AppStatus,
+    pub root: PathBuf,
+}
+
+impl AppState {
+    pub fn new(root: PathBuf) -> Self {
+        Self {
+            entries: Vec::new(),
+            selected: HashSet::new(),
+            cursor: 0,
+            status: AppStatus::Scanning,
+            root,
+        }
+    }
+
+    pub fn add_entry(&mut self, entry: ArtifactEntry) {
+        self.entries.push(entry);
+    }
+
+    pub fn mark_scan_done(&mut self) {
+        self.status = AppStatus::Ready;
+    }
+
+    pub fn move_up(&mut self) {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+        }
+    }
+
+    pub fn move_down(&mut self) {
+        if !self.entries.is_empty() && self.cursor < self.entries.len() - 1 {
+            self.cursor += 1;
+        }
+    }
+
+    pub fn toggle_selected(&mut self) {
+        if self.entries.is_empty() {
+            return;
+        }
+        if self.selected.contains(&self.cursor) {
+            self.selected.remove(&self.cursor);
+        } else {
+            self.selected.insert(self.cursor);
+        }
+    }
+
+    pub fn toggle_select_all(&mut self) {
+        if self.entries.is_empty() {
+            return;
+        }
+        if self.selected.len() == self.entries.len() {
+            self.selected.clear();
+        } else {
+            self.selected = (0..self.entries.len()).collect();
+        }
+    }
+
+    pub fn selected_size_bytes(&self) -> u64 {
+        self.selected
+            .iter()
+            .filter_map(|&i| self.entries.get(i))
+            .map(|e| e.size_bytes)
+            .sum()
+    }
+
+    pub fn selected_paths(&self) -> Vec<PathBuf> {
+        let mut indices: Vec<usize> = self.selected.iter().cloned().collect();
+        indices.sort_unstable();
+        indices
+            .iter()
+            .filter_map(|&i| self.entries.get(i))
+            .map(|e| e.path.clone())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scanner::{ArtifactEntry, Language};
+
+    fn make_entry(name: &str, size: u64) -> ArtifactEntry {
+        ArtifactEntry {
+            path: PathBuf::from(name),
+            language: Language::Rust,
+            size_bytes: size,
+        }
+    }
+
+    fn state_with_three() -> AppState {
+        let mut s = AppState::new(PathBuf::from("."));
+        s.add_entry(make_entry("a/target", 100));
+        s.add_entry(make_entry("b/target", 200));
+        s.add_entry(make_entry("c/target", 300));
+        s
+    }
+
+    #[test]
+    fn move_down_advances_cursor() {
+        let mut s = state_with_three();
+        s.move_down();
+        assert_eq!(s.cursor, 1);
+    }
+
+    #[test]
+    fn move_down_clamps_at_last() {
+        let mut s = state_with_three();
+        s.cursor = 2;
+        s.move_down();
+        assert_eq!(s.cursor, 2);
+    }
+
+    #[test]
+    fn move_up_clamps_at_zero() {
+        let mut s = state_with_three();
+        s.move_up();
+        assert_eq!(s.cursor, 0);
+    }
+
+    #[test]
+    fn toggle_selected_adds_and_removes() {
+        let mut s = state_with_three();
+        s.toggle_selected();
+        assert!(s.selected.contains(&0));
+        s.toggle_selected();
+        assert!(!s.selected.contains(&0));
+    }
+
+    #[test]
+    fn toggle_select_all_selects_all() {
+        let mut s = state_with_three();
+        s.toggle_select_all();
+        assert_eq!(s.selected.len(), 3);
+    }
+
+    #[test]
+    fn toggle_select_all_clears_when_all_selected() {
+        let mut s = state_with_three();
+        s.toggle_select_all();
+        s.toggle_select_all();
+        assert!(s.selected.is_empty());
+    }
+
+    #[test]
+    fn selected_size_sums_only_selected() {
+        let mut s = state_with_three();
+        s.selected.insert(0); // 100
+        s.selected.insert(2); // 300
+        assert_eq!(s.selected_size_bytes(), 400);
+    }
+
+    #[test]
+    fn selected_paths_returns_sorted() {
+        let mut s = state_with_three();
+        s.selected.insert(2);
+        s.selected.insert(0);
+        let paths = s.selected_paths();
+        assert_eq!(paths[0], PathBuf::from("a/target"));
+        assert_eq!(paths[1], PathBuf::from("c/target"));
+    }
+
+    #[test]
+    fn toggle_select_all_on_empty_list_is_noop() {
+        let mut s = AppState::new(PathBuf::from("."));
+        s.toggle_select_all(); // should not panic, selected stays empty
+        assert!(s.selected.is_empty());
+        s.toggle_select_all(); // still a noop
+        assert!(s.selected.is_empty());
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,3 @@
-// App state is not yet wired into main — suppress dead_code for this WIP module.
-#![allow(dead_code)]
-
 use crate::scanner::ArtifactEntry;
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -11,6 +8,7 @@ pub enum AppStatus {
     Ready,
     ConfirmDelete,
     Deleting,
+    #[allow(dead_code)]
     Done,
 }
 

--- a/src/deleter.rs
+++ b/src/deleter.rs
@@ -1,1 +1,82 @@
+use std::path::PathBuf;
 
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct DeleteResult {
+    pub path: PathBuf,
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+pub async fn delete_all(paths: Vec<PathBuf>) -> Vec<DeleteResult> {
+    let handles: Vec<_> = paths
+        .into_iter()
+        .map(|path| {
+            tokio::spawn(async move {
+                match tokio::fs::remove_dir_all(&path).await {
+                    Ok(_) => DeleteResult {
+                        path,
+                        success: true,
+                        error: None,
+                    },
+                    Err(e) => DeleteResult {
+                        path,
+                        success: false,
+                        error: Some(e.to_string()),
+                    },
+                }
+            })
+        })
+        .collect();
+
+    let mut results = Vec::new();
+    for handle in handles {
+        if let Ok(result) = handle.await {
+            results.push(result);
+        }
+    }
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn deletes_existing_directory() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("artifacts");
+        fs::create_dir(&dir).unwrap();
+        fs::write(dir.join("file.txt"), "data").unwrap();
+
+        let results = delete_all(vec![dir.clone()]).await;
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+        assert!(!dir.exists());
+    }
+
+    #[tokio::test]
+    async fn reports_error_for_missing_directory() {
+        let results = delete_all(vec![PathBuf::from("/nonexistent/xyz/abc")]).await;
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert!(results[0].error.is_some());
+    }
+
+    #[tokio::test]
+    async fn deletes_multiple_concurrently() {
+        let tmp = TempDir::new().unwrap();
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        fs::create_dir(&a).unwrap();
+        fs::create_dir(&b).unwrap();
+
+        let results = delete_all(vec![a.clone(), b.clone()]).await;
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| r.success));
+        assert!(!a.exists());
+        assert!(!b.exists());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,17 @@ mod deleter;
 mod scanner;
 mod ui;
 
+use app::{AppState, AppStatus};
 use clap::Parser;
-use std::path::PathBuf;
+use crossbeam_channel::unbounded;
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{backend::CrosstermBackend, widgets::ListState, Terminal};
+use scanner::ScanMessage;
+use std::{io, path::PathBuf, thread, time::Duration};
 
 #[derive(Parser)]
 #[command(name = "irona", about = "Reclaim disk space from build artifacts")]
@@ -14,7 +23,97 @@ struct Args {
     path: PathBuf,
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-    println!("Scanning: {}", args.path.display());
+    let root = args.path.canonicalize().unwrap_or(args.path);
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let result = run(&mut terminal, root);
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, root: PathBuf) -> anyhow::Result<()> {
+    let (tx, rx) = unbounded::<ScanMessage>();
+    let root_clone = root.clone();
+
+    thread::spawn(move || scanner::scan(root_clone, tx));
+
+    let mut state = AppState::new(root);
+    let mut list_state = ListState::default();
+    list_state.select(Some(0));
+
+    let rt = tokio::runtime::Runtime::new()?;
+
+    loop {
+        // Drain all pending channel messages this tick
+        loop {
+            match rx.try_recv() {
+                Ok(ScanMessage::Found(entry)) => state.add_entry(entry),
+                Ok(ScanMessage::Done) => {
+                    state.mark_scan_done();
+                    break;
+                }
+                Err(_) => break,
+            }
+        }
+
+        if !state.entries.is_empty() {
+            list_state.select(Some(state.cursor));
+        }
+
+        terminal.draw(|f| ui::render(f, &state, &mut list_state))?;
+
+        if event::poll(Duration::from_millis(16))? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                match (&state.status, key.code) {
+                    (_, KeyCode::Char('q')) => break,
+
+                    (AppStatus::Scanning | AppStatus::Ready, KeyCode::Up) => state.move_up(),
+                    (AppStatus::Scanning | AppStatus::Ready, KeyCode::Down) => state.move_down(),
+                    (AppStatus::Scanning | AppStatus::Ready, KeyCode::Char(' ')) => {
+                        state.toggle_selected()
+                    }
+                    (AppStatus::Scanning | AppStatus::Ready, KeyCode::Char('a')) => {
+                        state.toggle_select_all()
+                    }
+
+                    (AppStatus::Ready, KeyCode::Char('d')) if !state.selected.is_empty() => {
+                        state.status = AppStatus::ConfirmDelete;
+                    }
+
+                    (AppStatus::ConfirmDelete, KeyCode::Char('y')) => {
+                        state.status = AppStatus::Deleting;
+                        terminal.draw(|f| ui::render(f, &state, &mut list_state))?;
+                        let paths = state.selected_paths();
+                        rt.block_on(deleter::delete_all(paths));
+                        state.selected.clear();
+                        state.entries.retain(|e| e.path.exists());
+                        state.cursor = 0;
+                        state.status = AppStatus::Ready;
+                    }
+
+                    (AppStatus::ConfirmDelete, KeyCode::Char('n') | KeyCode::Esc) => {
+                        state.status = AppStatus::Ready;
+                    }
+
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,6 +1,3 @@
-// Scanner items are not yet wired into main — suppress dead_code for this WIP module.
-#![allow(dead_code)]
-
 use std::fs;
 use std::path::PathBuf;
 
@@ -28,6 +25,7 @@ impl std::fmt::Display for Language {
 #[derive(Debug, Clone)]
 pub struct ArtifactEntry {
     pub path: PathBuf,
+    #[allow(dead_code)]
     pub language: Language,
     pub size_bytes: u64,
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,1 +1,199 @@
+// Scanner items are not yet wired into main — suppress dead_code for this WIP module.
+#![allow(dead_code)]
 
+use std::fs;
+use std::path::PathBuf;
+
+use crossbeam_channel::Sender;
+use rayon::prelude::*;
+use walkdir::WalkDir;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Language {
+    Rust,
+    NodeJs,
+    CSharp,
+}
+
+impl std::fmt::Display for Language {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Language::Rust => write!(f, "Rust"),
+            Language::NodeJs => write!(f, "Node.js"),
+            Language::CSharp => write!(f, "C#"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ArtifactEntry {
+    pub path: PathBuf,
+    pub language: Language,
+    pub size_bytes: u64,
+}
+
+#[derive(Debug)]
+pub enum ScanMessage {
+    Found(ArtifactEntry),
+    Done,
+}
+
+/// Checks `dir` for marker files and returns artifact subdirectories found.
+/// Only returns a folder if its parent contains the expected marker — avoids
+/// false positives on unrelated folders named "bin" or "target".
+pub fn detect_artifacts(dir: &std::path::Path) -> Vec<(PathBuf, Language)> {
+    let mut found = Vec::new();
+
+    let names: Vec<String> = match fs::read_dir(dir) {
+        Ok(entries) => entries
+            .filter_map(|e| e.ok())
+            .filter_map(|e| e.file_name().into_string().ok())
+            .collect(),
+        Err(_) => return found,
+    };
+
+    // Rust: Cargo.toml -> target/
+    if names.iter().any(|n| n == "Cargo.toml") {
+        let p = dir.join("target");
+        if p.is_dir() {
+            found.push((p, Language::Rust));
+        }
+    }
+
+    // Node.js: package.json -> node_modules/
+    if names.iter().any(|n| n == "package.json") {
+        let p = dir.join("node_modules");
+        if p.is_dir() {
+            found.push((p, Language::NodeJs));
+        }
+    }
+
+    // C#: *.csproj or *.sln -> bin/ and obj/
+    if names
+        .iter()
+        .any(|n| n.ends_with(".csproj") || n.ends_with(".sln"))
+    {
+        for folder in &["bin", "obj"] {
+            let p = dir.join(folder);
+            if p.is_dir() {
+                found.push((p, Language::CSharp));
+            }
+        }
+    }
+
+    found
+}
+
+/// Sums sizes of all files under `path` recursively.
+pub fn dir_size(path: &std::path::Path) -> u64 {
+    WalkDir::new(path)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .filter_map(|e| e.metadata().ok())
+        .map(|m| m.len())
+        .sum()
+}
+
+pub fn scan(root: PathBuf, tx: Sender<ScanMessage>) {
+    // Phase 1: walkdir to collect candidate artifact paths (fast — metadata only).
+    // filter_entry skips descending INTO known artifact dirs, preventing
+    // redundant deep traversal of e.g. target/ which can be millions of files.
+    let mut candidates: Vec<(PathBuf, Language)> = Vec::new();
+
+    for entry in WalkDir::new(&root)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| {
+            if !e.file_type().is_dir() {
+                return true;
+            }
+            let name = e.file_name().to_string_lossy();
+            !matches!(
+                name.as_ref(),
+                "target" | "node_modules" | "bin" | "obj" | ".git"
+            )
+        })
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_dir())
+    {
+        candidates.extend(detect_artifacts(entry.path()));
+    }
+
+    // Phase 2: rayon calculates sizes in parallel, sends each result immediately.
+    candidates.par_iter().for_each(|(path, language)| {
+        let size_bytes = dir_size(path);
+        tx.send(ScanMessage::Found(ArtifactEntry {
+            path: path.clone(),
+            language: language.clone(),
+            size_bytes,
+        }))
+        .ok();
+    });
+
+    tx.send(ScanMessage::Done).ok();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn detects_rust_target() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "[package]").unwrap();
+        fs::create_dir(tmp.path().join("target")).unwrap();
+        let results = detect_artifacts(tmp.path());
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, Language::Rust);
+        assert!(results[0].0.ends_with("target"));
+    }
+
+    #[test]
+    fn detects_node_modules() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("package.json"), "{}").unwrap();
+        fs::create_dir(tmp.path().join("node_modules")).unwrap();
+        let results = detect_artifacts(tmp.path());
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, Language::NodeJs);
+        assert!(results[0].0.ends_with("node_modules"));
+    }
+
+    #[test]
+    fn detects_csharp_bin_and_obj() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("App.csproj"), "<Project/>").unwrap();
+        fs::create_dir(tmp.path().join("bin")).unwrap();
+        fs::create_dir(tmp.path().join("obj")).unwrap();
+        let results = detect_artifacts(tmp.path());
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|(_, l)| *l == Language::CSharp));
+    }
+
+    #[test]
+    fn no_false_positive_target_without_cargo_toml() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir(tmp.path().join("target")).unwrap();
+        let results = detect_artifacts(tmp.path());
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn no_false_positive_bin_without_csproj() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir(tmp.path().join("bin")).unwrap();
+        let results = detect_artifacts(tmp.path());
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn calculates_dir_size() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("a.txt"), "hello").unwrap(); // 5 bytes
+        fs::write(tmp.path().join("b.txt"), "world!").unwrap(); // 6 bytes
+        assert_eq!(dir_size(tmp.path()), 11);
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,3 @@
-// UI render is not yet wired into main — suppress dead_code for this WIP module.
-#![allow(dead_code)]
-
 use crate::app::{AppState, AppStatus};
 use ratatui::{
     layout::{Constraint, Direction, Layout},

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,1 +1,127 @@
+// UI render is not yet wired into main — suppress dead_code for this WIP module.
+#![allow(dead_code)]
 
+use crate::app::{AppState, AppStatus};
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+    Frame,
+};
+
+pub fn render(f: &mut Frame, state: &AppState, list_state: &mut ListState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(0),
+            Constraint::Length(3),
+        ])
+        .split(f.area());
+
+    // Header
+    let header_text = match &state.status {
+        AppStatus::Scanning => format!("scanning {}...", state.root.display()),
+        AppStatus::Ready => format!("done — {} items found", state.entries.len()),
+        AppStatus::ConfirmDelete => format!(
+            "Delete {} folder(s) ({})? [y/N]",
+            state.selected.len(),
+            format_bytes(state.selected_size_bytes())
+        ),
+        AppStatus::Deleting => "deleting...".to_string(),
+        AppStatus::Done => "done".to_string(),
+    };
+
+    f.render_widget(
+        Paragraph::new(header_text).block(Block::default().borders(Borders::ALL).title(" irona ")),
+        chunks[0],
+    );
+
+    // List
+    let items: Vec<ListItem> = state
+        .entries
+        .iter()
+        .enumerate()
+        .map(|(i, entry)| {
+            let check = if state.selected.contains(&i) {
+                "[✓]"
+            } else {
+                "[ ]"
+            };
+            let name = entry.path.file_name().unwrap_or_default().to_string_lossy();
+            let parent = entry.path.parent().unwrap_or(&entry.path).to_string_lossy();
+            ListItem::new(Line::from(vec![
+                Span::raw(format!(" {} ", check)),
+                Span::styled(format!("{:<15}", name), Style::default().fg(Color::Cyan)),
+                Span::raw(format!("  {:<45}", parent)),
+                Span::styled(
+                    format!("{:>10}", format_bytes(entry.size_bytes)),
+                    Style::default().fg(Color::Yellow),
+                ),
+            ]))
+        })
+        .collect();
+
+    f.render_stateful_widget(
+        List::new(items)
+            .block(Block::default().borders(Borders::ALL))
+            .highlight_style(
+                Style::default()
+                    .bg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        chunks[1],
+        list_state,
+    );
+
+    // Footer
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(
+                format!("Selected: {}   ", format_bytes(state.selected_size_bytes())),
+                Style::default().fg(Color::Green),
+            ),
+            Span::raw("↑↓ navigate  Space select  a all  d delete  q quit"),
+        ]))
+        .block(Block::default().borders(Borders::ALL)),
+        chunks[2],
+    );
+}
+
+pub fn format_bytes(bytes: u64) -> String {
+    if bytes >= 1_073_741_824 {
+        format!("{:.1} GB", bytes as f64 / 1_073_741_824.0)
+    } else if bytes >= 1_048_576 {
+        format!("{:.1} MB", bytes as f64 / 1_048_576.0)
+    } else if bytes >= 1_024 {
+        format!("{:.1} KB", bytes as f64 / 1_024.0)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_bytes_gb() {
+        assert_eq!(format_bytes(1_073_741_824), "1.0 GB");
+    }
+
+    #[test]
+    fn format_bytes_mb() {
+        assert_eq!(format_bytes(1_048_576), "1.0 MB");
+    }
+
+    #[test]
+    fn format_bytes_kb() {
+        assert_eq!(format_bytes(1_024), "1.0 KB");
+    }
+
+    #[test]
+    fn format_bytes_bytes() {
+        assert_eq!(format_bytes(512), "512 B");
+    }
+}


### PR DESCRIPTION
## Summary

- Tokio async deleter (`src/deleter.rs`): concurrent `remove_dir_all` via spawned tasks, returns `Vec<DeleteResult>` with per-path success/error; 3 new tests
- Full Ratatui event loop (`src/main.rs`): scanner streams `ScanMessage` into TUI live via crossbeam channel; keyboard nav (↑↓), space/a select, `d` → confirm → `y` deletes, `n`/Esc cancels, `q` quits
- Removed `#![allow(dead_code)]` from `scanner.rs`, `app.rs`, and `ui.rs` — all items are now used; residual dead variants/fields annotated with targeted `#[allow(dead_code)]`

## Test plan

- [ ] `cargo nextest run` — 22 tests pass (19 existing + 3 new deleter tests)
- [ ] `cargo build` — compiles clean, no errors
- [ ] `cargo clippy --all-targets -- -D warnings` — zero warnings/errors
- [ ] `cargo fmt` — no diff
- [ ] Manual smoke test: `cargo run -- <path>` — TUI opens, shows artifact folders, ↑↓ navigates, `q` quits (requires real TTY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)