### PR TITLE
feat: wire deleter + main event loop

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,3 @@
-// App state is not yet wired into main — suppress dead_code for this WIP module.
-#![allow(dead_code)]
-
 use crate::scanner::ArtifactEntry;
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -11,6 +8,7 @@ pub enum AppStatus {
     Ready,
     ConfirmDelete,
     Deleting,
+    #[allow(dead_code)]
     Done,
 }
 

--- a/src/deleter.rs
+++ b/src/deleter.rs
@@ -1,1 +1,81 @@
+use std::path::PathBuf;
 
+#[derive(Debug)]
+pub struct DeleteResult {
+    pub path: PathBuf,
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+pub async fn delete_all(paths: Vec<PathBuf>) -> Vec<DeleteResult> {
+    let handles: Vec<_> = paths
+        .into_iter()
+        .map(|path| {
+            tokio::spawn(async move {
+                match tokio::fs::remove_dir_all(&path).await {
+                    Ok(_) => DeleteResult {
+                        path,
+                        success: true,
+                        error: None,
+                    },
+                    Err(e) => DeleteResult {
+                        path,
+                        success: false,
+                        error: Some(e.to_string()),
+                    },
+                }
+            })
+        })
+        .collect();
+
+    let mut results = Vec::new();
+    for handle in handles {
+        if let Ok(result) = handle.await {
+            results.push(result);
+        }
+    }
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn deletes_existing_directory() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("artifacts");
+        fs::create_dir(&dir).unwrap();
+        fs::write(dir.join("file.txt"), "data").unwrap();
+
+        let results = delete_all(vec![dir.clone()]).await;
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+        assert!(!dir.exists());
+    }
+
+    #[tokio::test]
+    async fn reports_error_for_missing_directory() {
+        let results = delete_all(vec![PathBuf::from("/nonexistent/xyz/abc")]).await;
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert!(results[0].error.is_some());
+    }
+
+    #[tokio::test]
+    async fn deletes_multiple_concurrently() {
+        let tmp = TempDir::new().unwrap();
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        fs::create_dir(&a).unwrap();
+        fs::create_dir(&b).unwrap();
+
+        let results = delete_all(vec![a.clone(), b.clone()]).await;
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| r.success));
+        assert!(!a.exists());
+        assert!(!b.exists());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,17 @@ mod deleter;
 mod scanner;
 mod ui;
 
+use app::{AppState, AppStatus};
 use clap::Parser;
-use std::path::PathBuf;
+use crossbeam_channel::unbounded;
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{backend::CrosstermBackend, widgets::ListState, Terminal};
+use scanner::ScanMessage;
+use std::{io, path::PathBuf, thread, time::Duration};
 
 #[derive(Parser)]
 #[command(name = "irona", about = "Reclaim disk space from build artifacts")]
@@ -14,7 +23,115 @@ struct Args {
     path: PathBuf,
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-    println!("Scanning: {}", args.path.display());
+    let root = args.path.canonicalize().unwrap_or(args.path);
+
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+        original_hook(info);
+    }));
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let result = run(&mut terminal, root);
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, root: PathBuf) -> anyhow::Result<()> {
+    let (tx, rx) = unbounded::<ScanMessage>();
+    let root_clone = root.clone();
+
+    thread::spawn(move || scanner::scan(root_clone, tx));
+
+    let mut state = AppState::new(root);
+    let mut list_state = ListState::default();
+    list_state.select(Some(0));
+
+    let rt = tokio::runtime::Runtime::new()?;
+
+    loop {
+        // Drain all pending channel messages this tick
+        loop {
+            match rx.try_recv() {
+                Ok(ScanMessage::Found(entry)) => state.add_entry(entry),
+                Ok(ScanMessage::Done) => {
+                    state.mark_scan_done();
+                    break;
+                }
+                Err(crossbeam_channel::TryRecvError::Empty) => break,
+                Err(crossbeam_channel::TryRecvError::Disconnected) => {
+                    state.mark_scan_done();
+                    break;
+                }
+            }
+        }
+
+        if !state.entries.is_empty() {
+            list_state.select(Some(state.cursor));
+        }
+
+        terminal.draw(|f| ui::render(f, &state, &mut list_state))?;
+
+        if event::poll(Duration::from_millis(16))? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                match (&state.status, key.code) {
+                    (_, KeyCode::Char('q')) => break,
+
+                    (AppStatus::Scanning | AppStatus::Ready, KeyCode::Up) => state.move_up(),
+                    (AppStatus::Scanning | AppStatus::Ready, KeyCode::Down) => state.move_down(),
+                    (AppStatus::Scanning | AppStatus::Ready, KeyCode::Char(' ')) => {
+                        state.toggle_selected()
+                    }
+                    (AppStatus::Scanning | AppStatus::Ready, KeyCode::Char('a')) => {
+                        state.toggle_select_all()
+                    }
+
+                    (AppStatus::Ready, KeyCode::Char('d')) if !state.selected.is_empty() => {
+                        state.status = AppStatus::ConfirmDelete;
+                    }
+
+                    (AppStatus::ConfirmDelete, KeyCode::Char('y')) => {
+                        state.status = AppStatus::Deleting;
+                        terminal.draw(|f| ui::render(f, &state, &mut list_state))?;
+                        let paths = state.selected_paths();
+                        let results = rt.block_on(deleter::delete_all(paths));
+                        for r in &results {
+                            if !r.success {
+                                if let Some(ref err) = r.error {
+                                    eprintln!("failed to delete {}: {}", r.path.display(), err);
+                                }
+                            }
+                        }
+                        state.selected.clear();
+                        state.entries.retain(|e| e.path.exists());
+                        state.cursor = 0;
+                        state.status = AppStatus::Ready;
+                    }
+
+                    (AppStatus::ConfirmDelete, KeyCode::Char('n') | KeyCode::Esc) => {
+                        state.status = AppStatus::Ready;
+                    }
+
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -21,6 +22,7 @@ impl std::fmt::Display for Language {
 #[allow(dead_code)]
 pub struct ArtifactEntry {
     pub path: PathBuf,
+    #[allow(dead_code)]
     pub language: Language,
     pub size_bytes: u64,
 }
@@ -32,7 +34,6 @@ pub enum ScanMessage {
     Done,
 }
 
-use std::fs;
 
 /// Checks `dir` for marker files and returns artifact subdirectories found.
 /// Only returns a folder if its parent contains the expected marker — avoids

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,6 +1,3 @@
-// UI render is not yet wired into main — suppress dead_code for this WIP module.
-#![allow(dead_code)]
-
 use crate::app::{AppState, AppStatus};
 use ratatui::{
     layout::{Constraint, Direction, Layout},


### PR DESCRIPTION
Tokio async deleter (3 tests), full Ratatui event loop — scanner streams into TUI live, keyboard nav/select/confirm-delete all working. 22 tests total passing.

Closes #4 (replaces old feat/wire which had stacking conflicts)