### PR TITLE
feat: add gitignore-aware smart scan (#13)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 ratatui = "0.29"
 crossterm = "0.28"
 walkdir = "2"
+ignore = "0.4"
 crossbeam-channel = "0.5"
 rayon = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "fs", "macros"] }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # irona
 
-A terminal UI tool for reclaiming disk space from build artifacts. Scans your project directories and lets you select and delete artifact folders for a wide range of languages and package managers.
+A terminal UI tool for reclaiming disk space from build artifacts. Scans your project directories and lets you select and delete artifact folders for a wide range of languages and package managers. Also does a `.gitignore`-aware pass to catch any project-specific artifact directories not covered by the built-in language rules.
 
 ## Install
 
@@ -37,6 +37,7 @@ cargo install --path .
 
 - **↑ / ↓** — navigate entries
 - **Space** — select / deselect entry
+- **a** — select / deselect all
 - **d** — delete selected entries
 - **q / Esc** — quit
 
@@ -61,6 +62,16 @@ irona scans your home directory for build artifact folders and shows their size.
 | Haskell (Stack) | `stack.yaml` | `.stack-work/` |
 | Elm | `elm.json` | `elm-stuff/` |
 | Dart / Flutter | `pubspec.yaml` | `.dart_tool/`, `build/` |
+
+## Gitignore-aware scan
+
+In addition to the language rules above, irona walks every `.gitignore` file it encounters and surfaces any matching directories that exist on disk. This covers build outputs not hardcoded in irona — things like `dist/`, `out/`, `.cache/`, `coverage/`, `.next/`, or any project-specific pattern your `.gitignore` already documents.
+
+Each entry in the list is labelled with its source (`Rust`, `Node.js`, `gitignore`, etc.) so you can see at a glance where it was found.
+
+Directories that should never be deleted are excluded regardless of what `.gitignore` says: `.git`, `.vscode`, `.idea`, `.github`.
+
+If a directory is found by both a language rule and a `.gitignore` pattern, it appears once and is attributed to the language rule.
 
 ## Releasing
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -120,7 +120,6 @@ fn render_list(
                 .parent()
                 .unwrap_or(&row.entry.path)
                 .to_string_lossy();
-
             let (check, right_col, right_style) = match &row.delete_state {
                 DeleteState::Pending => (
                     if row.selected { "[✓]" } else { "[ ]" },
@@ -146,7 +145,11 @@ fn render_list(
             ListItem::new(Line::from(vec![
                 Span::raw(format!(" {} ", check)),
                 Span::styled(format!("{:<15}", name), Style::default().fg(Color::Cyan)),
-                Span::raw(format!("  {:<45}", parent)),
+                Span::raw(format!("  {:<33}", parent)),
+                Span::styled(
+                    format!("{:<12}", row.entry.language),
+                    Style::default().fg(Color::DarkGray),
+                ),
                 Span::styled(format!("{:>12}", right_col), right_style),
             ]))
         })

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,5 +1,12 @@
+use std::cell::RefCell;
+use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
+
+use crossbeam_channel::Sender;
+use ignore::gitignore::GitignoreBuilder;
+use rayon::prelude::*;
+use walkdir::WalkDir;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Language {
@@ -17,6 +24,7 @@ pub enum Language {
     Haskell,
     Elm,
     Dart,
+    GitIgnore,
 }
 
 impl std::fmt::Display for Language {
@@ -36,6 +44,7 @@ impl std::fmt::Display for Language {
             Language::Haskell => write!(f, "Haskell"),
             Language::Elm => write!(f, "Elm"),
             Language::Dart => write!(f, "Dart"),
+            Language::GitIgnore => write!(f, "gitignore"),
         }
     }
 }
@@ -217,9 +226,55 @@ pub fn detect_artifacts(dir: &std::path::Path) -> Vec<(PathBuf, Language)> {
     found
 }
 
-use crossbeam_channel::Sender;
-use rayon::prelude::*;
-use walkdir::WalkDir;
+const GITIGNORE_DENYLIST: &[&str] = &[".git", ".vscode", ".idea", ".github"];
+
+fn detect_gitignore_artifacts(
+    dir: &std::path::Path,
+    already_found: &HashSet<PathBuf>,
+) -> Vec<(PathBuf, Language)> {
+    let mut found = Vec::new();
+
+    let gitignore_path = dir.join(".gitignore");
+    if !gitignore_path.is_file() {
+        return found;
+    }
+
+    let mut builder = GitignoreBuilder::new(dir);
+    if builder.add(&gitignore_path).is_some() {
+        return found;
+    }
+    let Ok(gitignore) = builder.build() else {
+        return found;
+    };
+
+    let children = match fs::read_dir(dir) {
+        Ok(c) => c,
+        Err(_) => return found,
+    };
+
+    for child in children.filter_map(|e| e.ok()) {
+        let Ok(ft) = child.file_type() else { continue };
+        if !ft.is_dir() {
+            continue;
+        }
+        let path = child.path();
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if GITIGNORE_DENYLIST.contains(&name) {
+            continue;
+        }
+        if already_found.contains(&path) {
+            continue;
+        }
+        if gitignore.matched(&path, true).is_ignore() {
+            found.push((path, Language::GitIgnore));
+        }
+    }
+
+    found
+}
 
 /// Sums sizes of all files under `path` recursively.
 pub fn dir_size(path: &std::path::Path) -> u64 {
@@ -237,7 +292,10 @@ pub fn scan(root: PathBuf, tx: Sender<ScanMessage>) {
     // Phase 1: walkdir to collect candidate artifact paths (fast — metadata only).
     // filter_entry skips descending INTO known artifact dirs, preventing
     // redundant deep traversal of e.g. target/ which can be millions of files.
+    // found_paths is shared with filter_entry via RefCell so gitignore-matched
+    // dirs are also pruned from traversal as they are discovered.
     let mut candidates: Vec<(PathBuf, Language)> = Vec::new();
+    let found_paths: RefCell<HashSet<PathBuf>> = RefCell::new(HashSet::new());
 
     for entry in WalkDir::new(&root)
         .follow_links(false)
@@ -245,6 +303,9 @@ pub fn scan(root: PathBuf, tx: Sender<ScanMessage>) {
         .filter_entry(|e| {
             if !e.file_type().is_dir() {
                 return true;
+            }
+            if found_paths.borrow().contains(e.path()) {
+                return false;
             }
             let name = e.file_name().to_string_lossy();
             !matches!(
@@ -271,7 +332,26 @@ pub fn scan(root: PathBuf, tx: Sender<ScanMessage>) {
         .filter_map(|e| e.ok())
         .filter(|e| e.file_type().is_dir())
     {
-        candidates.extend(detect_artifacts(entry.path()));
+        let dir = entry.path();
+        let lang_hits = detect_artifacts(dir);
+        {
+            let mut fp = found_paths.borrow_mut();
+            for (path, _) in &lang_hits {
+                fp.insert(path.clone());
+            }
+        }
+        let gi_hits = {
+            let fp = found_paths.borrow();
+            detect_gitignore_artifacts(dir, &fp)
+        };
+        {
+            let mut fp = found_paths.borrow_mut();
+            for (path, _) in &gi_hits {
+                fp.insert(path.clone());
+            }
+        }
+        candidates.extend(lang_hits);
+        candidates.extend(gi_hits);
     }
 
     // Phase 2: rayon calculates sizes in parallel, sends each result immediately.
@@ -492,5 +572,76 @@ mod tests {
         fs::write(tmp.path().join("a.txt"), "hello").unwrap(); // 5 bytes
         fs::write(tmp.path().join("b.txt"), "world!").unwrap(); // 6 bytes
         assert_eq!(dir_size(tmp.path()), 11);
+    }
+
+    #[test]
+    fn gitignore_detects_matching_dir() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".gitignore"), "dist/\n").unwrap();
+        fs::create_dir(tmp.path().join("dist")).unwrap();
+        let results = detect_gitignore_artifacts(tmp.path(), &HashSet::new());
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, Language::GitIgnore);
+        assert!(results[0].0.ends_with("dist"));
+    }
+
+    #[test]
+    fn gitignore_ignores_nonexistent_dir() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".gitignore"), "dist/\n").unwrap();
+        let results = detect_gitignore_artifacts(tmp.path(), &HashSet::new());
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn gitignore_skips_denylist() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".gitignore"), ".vscode/\n.idea/\n").unwrap();
+        fs::create_dir(tmp.path().join(".vscode")).unwrap();
+        fs::create_dir(tmp.path().join(".idea")).unwrap();
+        let results = detect_gitignore_artifacts(tmp.path(), &HashSet::new());
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn gitignore_skips_already_found_paths() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".gitignore"), "target/\n").unwrap();
+        let target = tmp.path().join("target");
+        fs::create_dir(&target).unwrap();
+        let mut already = HashSet::new();
+        already.insert(target);
+        let results = detect_gitignore_artifacts(tmp.path(), &already);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn scan_deduplicates_lang_and_gitignore_for_same_dir() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "[package]").unwrap();
+        fs::write(tmp.path().join(".gitignore"), "target/\n").unwrap();
+        fs::create_dir(tmp.path().join("target")).unwrap();
+
+        let (tx, rx) = crossbeam_channel::unbounded();
+        scan(tmp.path().to_path_buf(), tx);
+
+        let mut entries: Vec<ArtifactEntry> = Vec::new();
+        for msg in rx {
+            match msg {
+                ScanMessage::Found(e) => entries.push(e),
+                ScanMessage::Done => break,
+            }
+        }
+
+        assert_eq!(entries.len(), 1, "target/ should appear exactly once");
+        assert_eq!(entries[0].language, Language::Rust);
+    }
+
+    #[test]
+    fn gitignore_no_file_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir(tmp.path().join("dist")).unwrap();
+        let results = detect_gitignore_artifacts(tmp.path(), &HashSet::new());
+        assert!(results.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Complements language-based scanning with a `.gitignore`-aware pass — walks every `.gitignore` encountered and surfaces matching directories that exist on disk (e.g. `dist/`, `out/`, `.cache/`, `.next/`)
- Adds a source label column to every list row (`Rust`, `Node.js`, `gitignore`, etc.) — the `language` field was stored but never rendered before
- Language-scanner results take precedence: if a dir is found by both scanners it appears once, attributed to the language rule

## Changes

- `Cargo.toml` — add `ignore = "0.4"` for correct gitignore pattern parsing (handles negations, `**` globs, directory-specific patterns)
- `src/scanner.rs` — `Language::GitIgnore` variant; `GITIGNORE_DENYLIST` (`.git`, `.vscode`, `.idea`, `.github`); `detect_gitignore_artifacts()`; `scan()` uses `RefCell<HashSet<PathBuf>>` shared with `filter_entry` so gitignore-matched dirs are pruned from WalkDir traversal just like hardcoded ones
- `src/render.rs` — language label span `{:<12}` in `DarkGray`; parent column trimmed 45→33 chars to keep row width stable
- `README.md` — new "Gitignore-aware scan" section; missing `a` keybinding added

## Test plan

- [x] `cargo nextest run` — 51/51 pass (6 new tests)
- [x] New `scan_deduplicates_lang_and_gitignore_for_same_dir` integration test: a Rust `target/` also listed in `.gitignore` appears exactly once
- [x] Pre-commit hooks (fmt, clippy, build) pass

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)