### PR TITLE
feat: MCP server for artifact cleanup (supersedes #17, with delete guard)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = "1"
 thiserror = "1"
 chrono = { version = "0.4", features = ["clock"] }
 tuirealm = { version = "3", features = ["crossterm"] }
+serde_json = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,37 @@ cargo install --path .
 
 irona scans your home directory for build artifact folders and shows their size. Select what you want to clean up and press `d` to delete.
 
+### MCP server
+
+irona can also run as a stdio [Model Context Protocol](https://modelcontextprotocol.io) server for AI tools:
+
+Install irona and make sure Cargo's bin directory is on your `PATH`:
+
+```bash
+cargo install irona-cli
+export PATH="$HOME/.cargo/bin:$PATH"
+```
+
+Using `irona` from `PATH` keeps MCP client configs portable and avoids hardcoding a local binary path such as `/home/alice/.cargo/bin/irona`.
+
+```json
+{
+  "mcpServers": {
+    "irona": {
+      "command": "irona",
+      "args": ["--mcp"]
+    }
+  }
+}
+```
+
+The MCP server exposes two tools:
+
+| Tool | Description |
+|---|---|
+| `scan_artifacts` | Scan a path and return artifact directories with sizes and detected language/source |
+| `clean_artifacts` | Delete a provided list of artifact directories and return per-path results plus freed bytes |
+
 ## Supported Languages
 
 | Language / Ecosystem | Marker file(s) | Artifact folder(s) |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ The MCP server exposes two tools:
 | `scan_artifacts` | Scan a path and return artifact directories with sizes and detected language/source |
 | `clean_artifacts` | Delete a provided list of artifact directories and return per-path results plus freed bytes |
 
+`clean_artifacts` refuses any path irona would not itself classify as an artifact. A directory only qualifies if a marker file sits beside it (`target/` next to a `Cargo.toml`) or a `.gitignore` rule matches it. Handing it an arbitrary path fails the whole call and deletes nothing, so a wrong path from the model cannot take out your work.
+
 ## Supported Languages
 
 | Language / Ecosystem | Marker file(s) | Artifact folder(s) |

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod components;
 mod deleter;
 mod errors;
+mod mcp;
 mod model;
 mod render;
 mod scanner;
@@ -28,12 +29,20 @@ use tuirealm::{
 #[derive(Parser)]
 #[command(name = "irona", about = "Reclaim disk space from build artifacts")]
 struct Args {
+    /// Run irona as a Model Context Protocol server over stdio.
+    #[arg(long)]
+    mcp: bool,
+
     #[arg(default_value = ".")]
     path: PathBuf,
 }
 
 fn main() -> Result<()> {
     let args = Args::parse();
+    if args.mcp {
+        return mcp::run();
+    }
+
     let root = args.path.canonicalize().unwrap_or(args.path);
 
     let original_hook = std::panic::take_hook();

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,452 @@
+use crate::{deleter, scanner};
+use anyhow::Result;
+use serde_json::{json, Value};
+use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
+
+const DEFAULT_PROTOCOL_VERSION: &str = "2025-06-18";
+
+pub fn run() -> Result<()> {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout().lock();
+
+    for line in stdin.lock().lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let response = match serde_json::from_str::<Value>(&line) {
+            Ok(message) => handle_message(message),
+            Err(err) => Some(error_response(
+                Value::Null,
+                -32700,
+                "Parse error",
+                Some(json!({
+                    "message": err.to_string(),
+                })),
+            )),
+        };
+
+        if let Some(response) = response {
+            serde_json::to_writer(&mut stdout, &response)?;
+            stdout.write_all(b"\n")?;
+            stdout.flush()?;
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_message(message: Value) -> Option<Value> {
+    let id = message.get("id").cloned()?;
+
+    let Some(method) = message.get("method").and_then(Value::as_str) else {
+        return Some(error_response(id, -32600, "Invalid Request", None));
+    };
+
+    match method {
+        "initialize" => Some(success_response(id, initialize_result(&message))),
+        "ping" => Some(success_response(id, json!({}))),
+        "tools/list" => Some(success_response(id, tools_list_result())),
+        "tools/call" => Some(
+            call_tool(&message)
+                .map(|result| success_response(id.clone(), result))
+                .unwrap_or_else(|err| error_response(id, -32602, &err, None)),
+        ),
+        _ => Some(error_response(id, -32601, "Method not found", None)),
+    }
+}
+
+fn initialize_result(message: &Value) -> Value {
+    let requested_protocol = message
+        .get("params")
+        .and_then(|params| params.get("protocolVersion"))
+        .and_then(Value::as_str)
+        .filter(|version| !version.trim().is_empty())
+        .unwrap_or(DEFAULT_PROTOCOL_VERSION);
+
+    json!({
+        "protocolVersion": requested_protocol,
+        "capabilities": {
+            "tools": {
+                "listChanged": false
+            }
+        },
+        "serverInfo": {
+            "name": "irona",
+            "title": "irona",
+            "version": env!("CARGO_PKG_VERSION")
+        },
+        "instructions": "Use scan_artifacts to find build artifact directories, then call clean_artifacts only for paths the user has approved for deletion."
+    })
+}
+
+fn tools_list_result() -> Value {
+    json!({
+        "tools": [
+            {
+                "name": "scan_artifacts",
+                "title": "Scan build artifacts",
+                "description": "Scan a directory and return build artifact directories with sizes and detected language or source.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Directory to scan. Defaults to the current working directory."
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "outputSchema": artifact_scan_output_schema(),
+                "annotations": {
+                    "readOnlyHint": true,
+                    "destructiveHint": false,
+                    "idempotentHint": true,
+                    "openWorldHint": false
+                }
+            },
+            {
+                "name": "clean_artifacts",
+                "title": "Clean build artifacts",
+                "description": "Delete the provided artifact directories and return a summary of freed space.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "paths": {
+                            "type": "array",
+                            "description": "Artifact directories to delete.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1
+                        }
+                    },
+                    "required": ["paths"],
+                    "additionalProperties": false
+                },
+                "outputSchema": clean_output_schema(),
+                "annotations": {
+                    "readOnlyHint": false,
+                    "destructiveHint": true,
+                    "idempotentHint": true,
+                    "openWorldHint": false
+                }
+            }
+        ]
+    })
+}
+
+fn call_tool(message: &Value) -> Result<Value, String> {
+    let params = message
+        .get("params")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "tools/call requires object params".to_string())?;
+    let name = params
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "tools/call requires a string tool name".to_string())?;
+    let arguments = params.get("arguments").unwrap_or(&Value::Null);
+
+    match name {
+        "scan_artifacts" => scan_artifacts(arguments),
+        "clean_artifacts" => clean_artifacts(arguments),
+        _ => Err(format!("Unknown tool: {name}")),
+    }
+}
+
+fn scan_artifacts(arguments: &Value) -> Result<Value, String> {
+    let path = match arguments {
+        Value::Null => PathBuf::from("."),
+        Value::Object(args) => args
+            .get("path")
+            .and_then(Value::as_str)
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(".")),
+        _ => return Err("scan_artifacts arguments must be an object".to_string()),
+    };
+    let root = path.canonicalize().unwrap_or(path);
+    let artifacts = scanner::scan_artifacts(&root);
+    let total_size_bytes: u64 = artifacts.iter().map(|entry| entry.size_bytes).sum();
+    let entries: Vec<Value> = artifacts
+        .into_iter()
+        .map(|entry| {
+            json!({
+                "path": entry.path.to_string_lossy(),
+                "language": entry.language.to_string(),
+                "size_bytes": entry.size_bytes
+            })
+        })
+        .collect();
+
+    let structured = json!({
+        "root": root.to_string_lossy(),
+        "count": entries.len(),
+        "total_size_bytes": total_size_bytes,
+        "artifacts": entries
+    });
+    let count = entries_len(&structured);
+    Ok(tool_result(
+        structured,
+        format!(
+            "Found {} artifact director{} totaling {} bytes.",
+            count,
+            if count == 1 { "y" } else { "ies" },
+            total_size_bytes
+        ),
+        false,
+    ))
+}
+
+fn clean_artifacts(arguments: &Value) -> Result<Value, String> {
+    let paths = arguments
+        .get("paths")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "clean_artifacts requires a paths array".to_string())?;
+    if paths.is_empty() {
+        return Err("clean_artifacts requires at least one path".to_string());
+    }
+
+    let mut delete_inputs = Vec::with_capacity(paths.len());
+    let mut original_paths = Vec::with_capacity(paths.len());
+    let mut sizes = Vec::with_capacity(paths.len());
+
+    for (index, path) in paths.iter().enumerate() {
+        let Some(path) = path.as_str() else {
+            return Err("clean_artifacts paths must all be strings".to_string());
+        };
+        let path = PathBuf::from(path);
+        sizes.push(scanner::dir_size(&path));
+        original_paths.push(path.clone());
+        delete_inputs.push((index, path));
+    }
+
+    let runtime = tokio::runtime::Runtime::new().map_err(|err| err.to_string())?;
+    let delete_results = runtime.block_on(deleter::delete_all(delete_inputs));
+
+    let mut total_freed_bytes = 0u64;
+    let mut deleted_count = 0usize;
+    let mut results = Vec::with_capacity(delete_results.len());
+
+    for result in delete_results {
+        let size_bytes = sizes.get(result.index).copied().unwrap_or_default();
+        let path = original_paths
+            .get(result.index)
+            .map(|path| path.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let elapsed_ms = millis_u64(result.elapsed);
+
+        match result.outcome {
+            Ok(()) => {
+                total_freed_bytes = total_freed_bytes.saturating_add(size_bytes);
+                deleted_count += 1;
+                results.push(json!({
+                    "path": path,
+                    "deleted": true,
+                    "size_bytes": size_bytes,
+                    "elapsed_ms": elapsed_ms
+                }));
+            }
+            Err(err) => {
+                results.push(json!({
+                    "path": path,
+                    "deleted": false,
+                    "size_bytes": size_bytes,
+                    "elapsed_ms": elapsed_ms,
+                    "error": err.to_string()
+                }));
+            }
+        }
+    }
+
+    let structured = json!({
+        "requested_count": paths.len(),
+        "deleted_count": deleted_count,
+        "total_freed_bytes": total_freed_bytes,
+        "results": results
+    });
+    Ok(tool_result(
+        structured,
+        format!(
+            "Deleted {deleted_count} of {} requested director{} and freed {total_freed_bytes} bytes.",
+            paths.len(),
+            if paths.len() == 1 { "y" } else { "ies" },
+        ),
+        false,
+    ))
+}
+
+fn artifact_scan_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "root": { "type": "string" },
+            "count": { "type": "integer" },
+            "total_size_bytes": { "type": "integer" },
+            "artifacts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "path": { "type": "string" },
+                        "language": { "type": "string" },
+                        "size_bytes": { "type": "integer" }
+                    },
+                    "required": ["path", "language", "size_bytes"]
+                }
+            }
+        },
+        "required": ["root", "count", "total_size_bytes", "artifacts"]
+    })
+}
+
+fn clean_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "requested_count": { "type": "integer" },
+            "deleted_count": { "type": "integer" },
+            "total_freed_bytes": { "type": "integer" },
+            "results": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "path": { "type": "string" },
+                        "deleted": { "type": "boolean" },
+                        "size_bytes": { "type": "integer" },
+                        "elapsed_ms": { "type": "integer" },
+                        "error": { "type": "string" }
+                    },
+                    "required": ["path", "deleted", "size_bytes", "elapsed_ms"]
+                }
+            }
+        },
+        "required": ["requested_count", "deleted_count", "total_freed_bytes", "results"]
+    })
+}
+
+fn tool_result(structured_content: Value, text: String, is_error: bool) -> Value {
+    json!({
+        "content": [
+            {
+                "type": "text",
+                "text": text
+            }
+        ],
+        "structuredContent": structured_content,
+        "isError": is_error
+    })
+}
+
+fn success_response(id: Value, result: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result
+    })
+}
+
+fn error_response(id: Value, code: i64, message: &str, data: Option<Value>) -> Value {
+    let mut error = json!({
+        "code": code,
+        "message": message
+    });
+
+    if let Some(data) = data {
+        error["data"] = data;
+    }
+
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": error
+    })
+}
+
+fn entries_len(structured: &Value) -> usize {
+    structured
+        .get("count")
+        .and_then(Value::as_u64)
+        .unwrap_or_default() as usize
+}
+
+fn millis_u64(duration: std::time::Duration) -> u64 {
+    duration.as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn lists_scan_and_clean_tools() {
+        let response = handle_message(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list"
+        }))
+        .unwrap();
+
+        let tools = response["result"]["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0]["name"], "scan_artifacts");
+        assert_eq!(tools[1]["name"], "clean_artifacts");
+    }
+
+    #[test]
+    fn scans_artifacts_with_structured_content() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "[package]").unwrap();
+        fs::create_dir(tmp.path().join("target")).unwrap();
+        fs::write(tmp.path().join("target").join("artifact.bin"), "data").unwrap();
+
+        let response = handle_message(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "scan_artifacts",
+                "arguments": {
+                    "path": tmp.path().to_string_lossy()
+                }
+            }
+        }))
+        .unwrap();
+
+        let structured = &response["result"]["structuredContent"];
+        assert_eq!(structured["count"], 1);
+        assert_eq!(structured["total_size_bytes"], 4);
+        assert_eq!(structured["artifacts"][0]["language"], "Rust");
+    }
+
+    #[test]
+    fn cleans_requested_artifacts() {
+        let tmp = TempDir::new().unwrap();
+        let artifact = tmp.path().join("target");
+        fs::create_dir(&artifact).unwrap();
+        fs::write(artifact.join("artifact.bin"), "data").unwrap();
+
+        let response = handle_message(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "clean_artifacts",
+                "arguments": {
+                    "paths": [artifact.to_string_lossy()]
+                }
+            }
+        }))
+        .unwrap();
+
+        let structured = &response["result"]["structuredContent"];
+        assert_eq!(structured["requested_count"], 1);
+        assert_eq!(structured["deleted_count"], 1);
+        assert_eq!(structured["total_freed_bytes"], 4);
+        assert!(!artifact.exists());
+    }
+}

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -217,6 +217,14 @@ fn clean_artifacts(arguments: &Value) -> Result<Value, String> {
             return Err("clean_artifacts paths must all be strings".to_string());
         };
         let path = PathBuf::from(path);
+        let path = path.canonicalize().unwrap_or(path);
+        if !scanner::is_artifact(&path) {
+            return Err(format!(
+                "refusing to delete {}: not a build artifact directory. \
+                 Only paths returned by scan_artifacts can be cleaned.",
+                path.display()
+            ));
+        }
         sizes.push(scanner::dir_size(&path));
         original_paths.push(path.clone());
         delete_inputs.push((index, path));
@@ -273,7 +281,7 @@ fn clean_artifacts(arguments: &Value) -> Result<Value, String> {
             paths.len(),
             if paths.len() == 1 { "y" } else { "ies" },
         ),
-        false,
+        deleted_count < paths.len(),
     ))
 }
 
@@ -424,8 +432,88 @@ mod tests {
     }
 
     #[test]
+    fn refuses_to_clean_non_artifact_directory() {
+        let tmp = TempDir::new().unwrap();
+        let documents = tmp.path().join("my-documents");
+        fs::create_dir(&documents).unwrap();
+        fs::write(documents.join("thesis.txt"), "important").unwrap();
+
+        let response = handle_message(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "clean_artifacts",
+                "arguments": {
+                    "paths": [documents.to_string_lossy()]
+                }
+            }
+        }))
+        .unwrap();
+
+        assert!(response["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("not a build artifact directory"));
+        assert!(documents.exists());
+    }
+
+    #[test]
+    fn refuses_whole_batch_when_one_path_is_not_an_artifact() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "[package]").unwrap();
+        let artifact = tmp.path().join("target");
+        fs::create_dir(&artifact).unwrap();
+        let documents = tmp.path().join("my-documents");
+        fs::create_dir(&documents).unwrap();
+
+        let response = handle_message(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "clean_artifacts",
+                "arguments": {
+                    "paths": [artifact.to_string_lossy(), documents.to_string_lossy()]
+                }
+            }
+        }))
+        .unwrap();
+
+        assert!(response["error"].is_object());
+        assert!(artifact.exists());
+        assert!(documents.exists());
+    }
+
+    #[test]
+    fn cleans_gitignore_detected_artifacts() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".gitignore"), "dist/\n").unwrap();
+        let dist = tmp.path().join("dist");
+        fs::create_dir(&dist).unwrap();
+        fs::write(dist.join("bundle.js"), "data").unwrap();
+
+        let response = handle_message(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "clean_artifacts",
+                "arguments": {
+                    "paths": [dist.to_string_lossy()]
+                }
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(response["result"]["structuredContent"]["deleted_count"], 1);
+        assert!(!dist.exists());
+    }
+
+    #[test]
     fn cleans_requested_artifacts() {
         let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "[package]").unwrap();
         let artifact = tmp.path().join("target");
         fs::create_dir(&artifact).unwrap();
         fs::write(artifact.join("artifact.bin"), "data").unwrap();

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -287,8 +287,7 @@ pub fn dir_size(path: &std::path::Path) -> u64 {
         .sum()
 }
 
-#[allow(dead_code)]
-pub fn scan(root: PathBuf, tx: Sender<ScanMessage>) {
+pub fn scan_artifacts(root: &std::path::Path) -> Vec<ArtifactEntry> {
     // Phase 1: walkdir to collect candidate artifact paths (fast — metadata only).
     // filter_entry skips descending INTO known artifact dirs, preventing
     // redundant deep traversal of e.g. target/ which can be millions of files.
@@ -297,7 +296,7 @@ pub fn scan(root: PathBuf, tx: Sender<ScanMessage>) {
     let mut candidates: Vec<(PathBuf, Language)> = Vec::new();
     let found_paths: RefCell<HashSet<PathBuf>> = RefCell::new(HashSet::new());
 
-    for entry in WalkDir::new(&root)
+    for entry in WalkDir::new(root)
         .follow_links(false)
         .into_iter()
         .filter_entry(|e| {
@@ -354,16 +353,22 @@ pub fn scan(root: PathBuf, tx: Sender<ScanMessage>) {
         candidates.extend(gi_hits);
     }
 
-    // Phase 2: rayon calculates sizes in parallel, sends each result immediately.
-    candidates.par_iter().for_each(|(path, language)| {
-        let size_bytes = dir_size(path);
-        tx.send(ScanMessage::Found(ArtifactEntry {
+    // Phase 2: rayon calculates sizes in parallel.
+    candidates
+        .par_iter()
+        .map(|(path, language)| ArtifactEntry {
             path: path.clone(),
             language: language.clone(),
-            size_bytes,
-        }))
-        .ok();
-    });
+            size_bytes: dir_size(path),
+        })
+        .collect()
+}
+
+#[allow(dead_code)]
+pub fn scan(root: PathBuf, tx: Sender<ScanMessage>) {
+    for entry in scan_artifacts(&root) {
+        tx.send(ScanMessage::Found(entry)).ok();
+    }
 
     tx.send(ScanMessage::Done).ok();
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -287,7 +287,7 @@ pub fn dir_size(path: &std::path::Path) -> u64 {
         .sum()
 }
 
-pub fn scan_artifacts(root: &std::path::Path) -> Vec<ArtifactEntry> {
+fn collect_candidates(root: &std::path::Path) -> Vec<(PathBuf, Language)> {
     // Phase 1: walkdir to collect candidate artifact paths (fast — metadata only).
     // filter_entry skips descending INTO known artifact dirs, preventing
     // redundant deep traversal of e.g. target/ which can be millions of files.
@@ -353,8 +353,28 @@ pub fn scan_artifacts(root: &std::path::Path) -> Vec<ArtifactEntry> {
         candidates.extend(gi_hits);
     }
 
-    // Phase 2: rayon calculates sizes in parallel.
     candidates
+}
+
+/// Confirms `path` is a directory the scanner itself would classify as an
+/// artifact. Destructive callers that accept paths from outside — the MCP
+/// `clean_artifacts` tool — gate on this so an arbitrary directory can never
+/// be handed to `remove_dir_all`.
+pub fn is_artifact(path: &std::path::Path) -> bool {
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    if detect_artifacts(parent).iter().any(|(p, _)| p == path) {
+        return true;
+    }
+    detect_gitignore_artifacts(parent, &HashSet::new())
+        .iter()
+        .any(|(p, _)| p == path)
+}
+
+pub fn scan_artifacts(root: &std::path::Path) -> Vec<ArtifactEntry> {
+    // Phase 2: rayon calculates sizes in parallel.
+    collect_candidates(root)
         .par_iter()
         .map(|(path, language)| ArtifactEntry {
             path: path.clone(),
@@ -366,9 +386,18 @@ pub fn scan_artifacts(root: &std::path::Path) -> Vec<ArtifactEntry> {
 
 #[allow(dead_code)]
 pub fn scan(root: PathBuf, tx: Sender<ScanMessage>) {
-    for entry in scan_artifacts(&root) {
-        tx.send(ScanMessage::Found(entry)).ok();
-    }
+    // Phase 2 streams each entry as its size lands, so the TUI fills in while
+    // dir_size is still walking the remaining candidates.
+    collect_candidates(&root)
+        .par_iter()
+        .for_each(|(path, language)| {
+            tx.send(ScanMessage::Found(ArtifactEntry {
+                path: path.clone(),
+                language: language.clone(),
+                size_bytes: dir_size(path),
+            }))
+            .ok();
+        });
 
     tx.send(ScanMessage::Done).ok();
 }
@@ -648,5 +677,62 @@ mod tests {
         fs::create_dir(tmp.path().join("dist")).unwrap();
         let results = detect_gitignore_artifacts(tmp.path(), &HashSet::new());
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn is_artifact_accepts_marker_backed_dir() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "[package]").unwrap();
+        fs::create_dir(tmp.path().join("target")).unwrap();
+        assert!(is_artifact(&tmp.path().join("target")));
+    }
+
+    #[test]
+    fn is_artifact_accepts_gitignore_matched_dir() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".gitignore"), "dist/\n").unwrap();
+        fs::create_dir(tmp.path().join("dist")).unwrap();
+        assert!(is_artifact(&tmp.path().join("dist")));
+    }
+
+    #[test]
+    fn is_artifact_rejects_plain_directory() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir(tmp.path().join("my-documents")).unwrap();
+        assert!(!is_artifact(&tmp.path().join("my-documents")));
+    }
+
+    #[test]
+    fn is_artifact_rejects_target_without_cargo_toml() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir(tmp.path().join("target")).unwrap();
+        assert!(!is_artifact(&tmp.path().join("target")));
+    }
+
+    #[test]
+    fn is_artifact_rejects_denylisted_dir() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".gitignore"), ".git/\n").unwrap();
+        fs::create_dir(tmp.path().join(".git")).unwrap();
+        assert!(!is_artifact(&tmp.path().join(".git")));
+    }
+
+    #[test]
+    fn scan_streams_each_entry_before_done() {
+        let tmp = TempDir::new().unwrap();
+        for name in ["a", "b", "c"] {
+            let proj = tmp.path().join(name);
+            fs::create_dir(&proj).unwrap();
+            fs::write(proj.join("Cargo.toml"), "[package]").unwrap();
+            fs::create_dir(proj.join("target")).unwrap();
+        }
+
+        let (tx, rx) = crossbeam_channel::unbounded();
+        scan(tmp.path().to_path_buf(), tx);
+
+        let msgs: Vec<ScanMessage> = rx.into_iter().collect();
+        assert_eq!(msgs.len(), 4);
+        assert!(matches!(msgs[3], ScanMessage::Done));
+        assert!(msgs[..3].iter().all(|m| matches!(m, ScanMessage::Found(_))));
     }
 }


### PR DESCRIPTION
Supersedes #17. Contains @NotYash1066's original commit unchanged, plus one fix commit on top.

I could not push directly to the fork branch for #17, so this branch carries their work forward. Their commit is preserved, so authorship survives in history. Close #17 once this merges.

## Why the extra commit

**`clean_artifacts` deleted any path handed to it.** Caller-supplied strings went straight to `remove_dir_all` with no validation. The caller here is a model, so a hallucinated or prompt-injected path meant silent recursive deletion. Verified against the built binary before the fix:

```
$ echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"clean_artifacts",
  "arguments":{"paths":["/tmp/irona-notartifact/my-documents"]}}}' | irona --mcp
{"result":{"structuredContent":{"deleted_count":1,"total_freed_bytes":10, ...
>>> DELETED
```

That directory held a text file and no marker. `destructiveHint: true` is advisory — clients are not obliged to confirm on it.

Every path is now canonicalized and gated on a new `scanner::is_artifact`, which accepts a directory only when a marker file sits beside it (`target/` next to a `Cargo.toml`) or a `.gitignore` rule matches it. One bad path fails the whole call and deletes nothing. Same input after the fix:

```
{"error":{"code":-32602,"message":"refusing to delete /tmp/irona-notartifact/my-documents:
 not a build artifact directory. Only paths returned by scan_artifacts can be cleaned."}}
>>> SURVIVED
```

**The TUI lost its streaming scan.** Splitting `scan` into `scan_artifacts` made the parallel `dir_size` phase collect into a `Vec` before sending anything, so the list stayed empty until the whole scan finished — noticeable on a large workspace, since `dir_size` is the slow phase. Phase 1 is now a shared `collect_candidates` helper: `scan` streams each entry as its size lands, `scan_artifacts` collects for MCP.

Also flips `isError` when some deletions fail, instead of always reporting `false`.

## Verification

- `cargo nextest run` — 63 pass (54 from #17, 9 new)
- `cargo clippy --all-targets -- -D warnings` — clean
- new tests: non-artifact refused, mixed batch refused wholesale, gitignore-detected dir still cleanable, `is_artifact` accepts marker-backed and gitignore-matched dirs, rejects plain dirs / `target/` without `Cargo.toml` / denylisted `.git`, and `scan` emits all `Found` messages before `Done`
- live stdio check of both the refusal and a real `target/` still being cleaned

## Not addressed

`initialize` still echoes back whatever `protocolVersion` the client sends, including unsupported ones, and `scan_artifacts` has no cap on result count. Both are minor and worth a follow-up rather than holding this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)